### PR TITLE
fix(statistics): remove double-escaping from data-* attributes

### DIFF
--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -25,7 +25,13 @@
     UTA: '#000000', CHI: '#CF0A2C'
   };
 
-  const decodeEntities = s => (s || '').replace(/&amp;/g, '&').replace(/&#38;/g, '&');
+    // Robust HTML entity decoder (handles &amp;, &#38;, &#039;, &quot;, etc.)
+  const __decEl = document.createElement('textarea');
+  const decodeEntities = s => {
+    if (s == null) return '';
+    __decEl.innerHTML = String(s);
+    return __decEl.value;
+  };
   const extractNhlId = raw => { const m = String(raw || '').match(/(\d{6,8})/); return m ? m[1] : ''; };
   function getSeasonSlug(d = new Date()) { const y = d.getFullYear(), m = d.getMonth() + 1; const start = (m >= 7) ? y : (y - 1), end = start + 1; return '' + start + end; }
   const mugsUrl = (team, id, season) => `https://assets.nhle.com/mugs/nhl/${season || getSeasonSlug()}/${(team || '').toUpperCase().replace(/[^A-Z]/g, '')}/${id}.png`;
@@ -77,11 +83,11 @@
     if (!li) return;
     const feature = card.querySelector('[data-card-feature]');
     if (!feature) return;
-    const name = li.getAttribute('data-name') || '—';
-    const team = li.getAttribute('data-team') || '';
+    const name = decodeEntities(li.getAttribute('data-name') || '—');
+    const team = decodeEntities(li.getAttribute('data-team') || '');
     const teamNum = li.getAttribute('data-teamnum') || '';
-    const metric = li.getAttribute('data-metric') || '';
-    const val = li.getAttribute('data-valtext') || li.getAttribute('data-val') || '—';
+    const metric = decodeEntities(li.getAttribute('data-metric') || '');
+    const val = decodeEntities(li.getAttribute('data-valtext') || li.getAttribute('data-val') || '—');
 
     // Name (stacked)
     setStackedName(feature, name);


### PR DESCRIPTION
﻿## Summary
 Replaced entity decoder and decoded all visible text from data-* attributes before rendering (name, team, metric, value). Prevents output like O&#039;Reilly and &amp; from appearing literally in the UI.

## Checklist
- [#] Linked issue (e.g. Closes #123)
- [#] Tested locally
- [#] Docs updated (if needed)

## Risk/Impact
Files: assets/js/statistics.js

Risk: Low — limited to text decoding; no structural or sorting logic changes.

Test:
Open Statistics → Leaders.
Hover different list items; verify name (stacked), metric label, value, and team show proper characters (', &, quotes) with no entities visible.
Confirm sorting, tabs, rows dropdowns, and avatars still function as before.  
