### PR TITLE
.gitignore addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Thumbs.db
 uploads/
 logs/
 backups/
+
+.gitmessage.txt


### PR DESCRIPTION
Summary:
- Addition of .gitmessage.txt to .gitignore

Files:
- .gitignore

Risk:
- Low

Test:
1. Check if .gitmessage.txt is now greyed out.

﻿## Summary
Describe the change and why.

## Checklist
- [#] Tested locally


## Risk/Impact
Added to .gitignore.  Low risk.
