### PR TITLE
stats(js): de-dupe avatar fallback; use sanitized id for all mug URLs

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,19 +1,24 @@
-﻿name: PHP Lint
+﻿name: php-lint
 
 on:
+  pull_request:
+    branches: [ dev, main ]
+    paths:
+      - '**/*.php'
+      - '.github/workflows/php-lint.yml'
+  push:
+    branches: [ dev ]   # runs when you push directly to dev
+    paths:
+      - '**/*.php'
+      - '.github/workflows/php-lint.yml'
   workflow_dispatch:
 
-# 👇 Explicit least-privilege token permissions (recommended)
 permissions:
   contents: read
 
 jobs:
   php-lint:
     runs-on: ubuntu-latest
-    # (optional redundancy) keep at job level too
-    permissions:
-      contents: read
-
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,15 +1,24 @@
 ﻿name: PHP Lint
+
 on:
-  push: { branches: [ main ] }
-  pull_request: { branches: [ main ] }
   workflow_dispatch:
+
+# 👇 Explicit least-privilege token permissions (recommended)
+permissions:
+  contents: read
+
 jobs:
   php-lint:
     runs-on: ubuntu-latest
+    # (optional redundancy) keep at job level too
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
-        with: { php-version: "8.2" }
+        with:
+          php-version: '8.2'
       - name: Syntax check
         run: |
           find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 -P 4 php -l

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -227,33 +227,6 @@
           img.src = String(remote2);
         }
       };
-        add(`${base}${safeId}.png`);
-        add(`${base}${safeId}.jpg`);
-        if (teamNum) add(`${base}${teamNum}/${safeId}.png`);
-        add(`${base}${cleanTeam}/${safeId}.png`);
-      }
-
-      // Build both remote URLs from the same sanitized ID
-      const remote1 = mugsUrl(team, safeId);
-      const remote2 = cmsUrl(safeId);
-
-      let idx = 0;
-      const tryNext = () => {
-        if (idx < sources.length) {
-          img.onerror = tryNext;
-          // codeql[js/xss-through-dom]: assigning a URL to an <img> attribute; not parsing HTML.
-          img.src = String(sources[idx++]);
-        } else if (idx === sources.length) {
-          idx++;
-          // codeql[js/xss-through-dom]: league-controlled URL; attribute assignment only.
-          img.src = String(remote1);
-          img.onerror = tryNext;
-        } else {
-          img.onerror = null;
-          // codeql[js/xss-through-dom]: final fallback URL; attribute assignment only.
-          img.src = String(remote2);
-        }
-      };
 
       tryNext();
       img.alt = name + ' headshot';


### PR DESCRIPTION
- Remove accidental nested tryNext/idx causing 5 syntax errors
- Build sources, remote1, and remote2 from the same sanitized id
- Keep original behavior and CodeQL annotations

﻿## Summary
Describe the change and why.

## Checklist
- [ ] Linked issue (e.g. Closes #123)
- [ ] Tested locally
- [ ] Screenshots/UI notes if frontend
- [ ] Docs updated (if needed)

## Risk/Impact
Any migrations or config changes?
